### PR TITLE
fix-bug: can not register again when heartbeat response 404

### DIFF
--- a/eureka/go.mod
+++ b/eureka/go.mod
@@ -1,4 +1,6 @@
-module github.com/HikoQiu/go-eureka-client/eureka
+module github.com/darcydai/go-eureka-client/eureka
+
+go 1.18
 
 replace (
 	golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac => github.com/golang/crypto v0.0.0-20180820150726-614d502a4dac
@@ -9,4 +11,11 @@ replace (
 require (
 	github.com/miekg/dns v1.0.15
 	gopkg.in/resty.v1 v1.10.2
+)
+
+require (
+	golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac // indirect
+	golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1 // indirect
+	golang.org/x/sync v0.8.0 // indirect
+	golang.org/x/sys v0.25.0 // indirect
 )

--- a/eureka/go.sum
+++ b/eureka/go.sum
@@ -1,5 +1,12 @@
+github.com/golang/crypto v0.0.0-20180820150726-614d502a4dac h1:CTlcobgUKCEymD3P3693BUmy15cF1QiGji0PnANoptk=
+github.com/golang/crypto v0.0.0-20180820150726-614d502a4dac/go.mod h1:uZvAcrsnNaCxlh1HorK5dUQHGmEKPh2H/Rl1kehswPo=
+github.com/golang/net v0.0.0-20180826012351-8a410e7b638d h1:XXZ0nKFacC83c+kBG0i/rJdPj9HtnO0OKefFKaELC1M=
 github.com/golang/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:98y8FxUyMjTdJ5eOj/8vzuiVO14/dkJ98NYhEPG8QGY=
 github.com/miekg/dns v1.0.15 h1:9+UupePBQCG6zf1q/bGmTO1vumoG13jsrbWOSX1W6Tw=
 github.com/miekg/dns v1.0.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/resty.v1 v1.10.2 h1:0kn7/nSP3fjAddBOjnYDq0rmyvVFvuk4iFtWQUWptjc=
 gopkg.in/resty.v1 v1.10.2/go.mod h1:nrgQYbPhkRfn2BfT32NNTLfq3K9NuHRB0MsAcA9weWY=

--- a/eureka/server_api_test.go
+++ b/eureka/server_api_test.go
@@ -55,13 +55,13 @@ func Test_SendHeartbeat(t *testing.T) {
     t.Log("Eureka server url: ", urls[0])
 
     // TEST NOT-FOUND
-    err = NewEurekaServerApi(urls[0]).SendHeartbeat("NOT-FOUND", "NOT-FOUND")
+    _, err = NewEurekaServerApi(urls[0]).SendHeartbeat("NOT-FOUND", "NOT-FOUND")
     if err != nil {
         t.Log("NOT-FOUND-TEST: ", err.Error())
     }
 
     // TEST APP
-    err = NewEurekaServerApi(urls[0]).SendHeartbeat(test_app_name, genDefaultInstanceId(test_app_name, test_instance_port))
+    _, err = NewEurekaServerApi(urls[0]).SendHeartbeat(test_app_name, genDefaultInstanceId(test_app_name, test_instance_port))
     if err != nil {
         t.Log("TEST heartbeat, app=", test_app_name, ", err=", err.Error())
     }


### PR DESCRIPTION


The main changes in the current PR are as follows:
1. When the Eureka server crashes or encounters a network issue, the registration information on the Eureka server side will expire. When the client sends a heartbeat again, the server will return an HTTP 404 status code. Upon receiving this status code, the client will trigger a re-registration. This logic is present in the Java version.
2. During the service startup, the Java client does not actually register with the status STARTING and then update to UP. Based on my debug verification of the Java version, it registers directly with the status UP. Therefore, registering and then modifying the status is meaningless.
